### PR TITLE
Fixed the compilation warning and added a success message

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,1 +1,2 @@
 x86_64-w64-mingw32-gcc -m64 -mwindows -c injectEtwBypass.c -o injectEtwBypass.o -masm=intel -Wall -fno-asynchronous-unwind-tables -nostdlib -fno-ident -Wl,-Tlinker.ld,--no-seh
+echo "Succesfully compiled, you can load 'injectEtwBypass.cna' into Cobalt-Strike and use the command 'injectEtwBypass PID'"

--- a/injectEtwBypass.c
+++ b/injectEtwBypass.c
@@ -1,6 +1,8 @@
 // Author: Bobby Cooke (@0xBoku) // SpiderLabs // github.com/boku7 // https://www.linkedin.com/in/bobby-cooke/ // https://0xboku.com
 // Credits / References: Reenz0h (@SEKTOR7net), Adam Chester (@_xpn_ / @TrustedSec), Chetan Nayak (@NinjaParanoid), 
 //                       Vivek Ramachandran (@vivekramac), Pavel Yosifovich (@zodiacon), @smelly__vx & @am0nsec, @ajpc500, Matt Kingstone (@n00bRage)
+#pragma GCC diagnostic ignored "-Wint-to-pointer-cast"
+
 #include <windows.h>
 #include "beacon.h"
 


### PR DESCRIPTION
* Disabled the -Wint-to-pointer-cast warning in injectEtwBypass.c
* Added a success message if the compilation was successful in compile.sh
* Going to buy a beer pack for your awesome project